### PR TITLE
Add: new randomize mechanisms

### DIFF
--- a/og_bruce.xml
+++ b/og_bruce.xml
@@ -79,8 +79,8 @@
 
             <!-- Extra mass box to randomize the COM ####################################################-->
             <body name="random_mass" pos="0.02 0 -0.1" quat="1 0 0 0">
-                <!-- Instead of separate <inertial> (causes bug for only mjx), just give the geom its mass: -->
-                <geom type="box" size="0.05 0.05 0.05" mass="0.5" rgba="0.8 0.2 0.2 0.1"/>
+                <joint name="random_mass"  type="slide" axis="0 0 1" limited="true" range="-0.001 0.001" stiffness="1" damping="1"/>
+                <geom  name="random_mass_geom" type="box" size="0.05 0.05 0.05" rgba="0.8 0.2 0.2 0.1" mass="0.5" />
             </body>
             <!-- Extra mass box to randomize the COM ####################################################-->
 
@@ -374,10 +374,11 @@
     </contact>
 
 
-    <keyframe>        
+    <keyframe>
         <key name="home"
             qpos="0.0 0.0 0.48
                     1 0 0 0
+                    0
                     0 0 0 0.4 -0.4 -0.03 -0.4 0 0 0
                     0 0 0 0.4 -0.4 -0.03 -0.4 0 0 0
                     0 1.4 0
@@ -393,6 +394,7 @@
                 0 -1.4 0"
             ctrl="0 0 0 0.4 -0.0 0 0 0 0.4 -0.0 0 1.4 0 0 -1.4 0"/> -->
     </keyframe>
+
  </mujoco>
 
  


### PR DESCRIPTION
This pull request includes changes to the `og_bruce.xml` file to update the configuration of the random mass box and adjust the keyframe settings. The most important changes include modifying the `random_mass` body and adding a new key position.

Updates to random mass box configuration:

* Changed the `random_mass` body to include a `joint` element with specific attributes and updated the `geom` element to include a name attribute.

Adjustments to keyframe settings:

* Added a new key position with a value of `0` in the `home` key configuration.
* Added a blank line after the `keyframe` element for better readability.